### PR TITLE
Issue #113 - Added a configuration sanity check to ensure PPM limit configurations respect sensor range/sensitivity

### DIFF
--- a/src/prometeo_config.json
+++ b/src/prometeo_config.json
@@ -1,11 +1,11 @@
 {
 "windows_and_limits":
     [
-        { "label": "10min", "mins": 10,  "gas_limits": { "carbon_monoxide": 420, "nitrogen_dioxide": 20,  "formaldehyde": 14, "acrolein": 0.44 }},
-        { "label": "30min", "mins": 30,  "gas_limits": { "carbon_monoxide": 150, "nitrogen_dioxide": 15,  "formaldehyde": 14, "acrolein": 0.18 }},
-        { "label": "60min", "mins": 60,  "gas_limits": { "carbon_monoxide": 83,  "nitrogen_dioxide": 12,  "formaldehyde": 14, "acrolein": 0.1  }},
-        { "label": "4hr",   "mins": 240, "gas_limits": { "carbon_monoxide": 33,  "nitrogen_dioxide": 8.2, "formaldehyde": 14, "acrolein": 0.1  }},
-        { "label": "8hr",   "mins": 480, "gas_limits": { "carbon_monoxide": 27,  "nitrogen_dioxide": 6.7, "formaldehyde": 14, "acrolein": 0.1  }}
+        { "label": "10min", "mins": 10,  "gas_limits": { "carbon_monoxide": 420, "nitrogen_dioxide": 5,  "formaldehyde": 14, "acrolein": 0.44 }},
+        { "label": "30min", "mins": 30,  "gas_limits": { "carbon_monoxide": 150, "nitrogen_dioxide": 1,  "formaldehyde": 14, "acrolein": 0.18 }},
+        { "label": "60min", "mins": 60,  "gas_limits": { "carbon_monoxide": 83,  "nitrogen_dioxide": 1,  "formaldehyde": 14, "acrolein": 0.1  }},
+        { "label": "4hr",   "mins": 240, "gas_limits": { "carbon_monoxide": 33,  "nitrogen_dioxide": 0.5, "formaldehyde": 14, "acrolein": 0.1  }},
+        { "label": "8hr",   "mins": 480, "gas_limits": { "carbon_monoxide": 27,  "nitrogen_dioxide": 0.5, "formaldehyde": 14, "acrolein": 0.1  }}
     ],
 "supported_gases" :["carbon_monoxide", "nitrogen_dioxide"],
 "yellow_warning_percent" : 80,


### PR DESCRIPTION
Issue #113 - Added a configuration sanity check to ensure PPM limit configurations respect sensor range/sensitivity. Updated nitrogen dioxide limits to roughly match the 0.5-1ppm European directives, as some of the previous AEGL limits were outside the sensor's range. These are placeholder values, Marco will be providing real values for this sensor shortly.