### PR TITLE
Issue #115 Handle dropouts in the Prometeo sensor data by substituting TWA window-specific averages for missing values

### DIFF
--- a/src/GasExposureAnalytics.py
+++ b/src/GasExposureAnalytics.py
@@ -22,6 +22,14 @@ GREEN = 1
 YELLOW = 2
 RED = 3
 
+# Cache Constants
+DATA_START = 'data_start'
+DATA_END = 'data_end'
+WINDOW_START = 'window_start'
+WINDOW_END = 'window_end'
+OVERLAP_MINS = 'overlap_mins'
+PROPORTION_OF_WINDOW = 'proportion_of_window'
+
 # Status constants - percentages that define green/red status (yellow is the name of a configuration parameter)
 GREEN_RANGE_START = 0
 RED_RANGE_START = 99
@@ -34,6 +42,7 @@ SUPPORTED_GASES_PROPERTY = 'supported_gases'
 YELLOW_WARNING_PERCENT_PROPERTY = 'yellow_warning_percent'
 SAFE_ROUNDING_FACTOR_PROPERTY = 'safe_rounding_factor'
 GAS_LIMITS_PROPERTY = 'gas_limits'
+AUTOFILL_MINS_PROPERTY = 'autofill_missing_sensor_logs_up_to_N_mins'
 
 # Sensor range limitations. These are intentionally hard-coded and not configured. They're used to cross-check
 # that the PPM limits configured for each time-window respects the sensitivity range of the sensors.
@@ -99,6 +108,19 @@ class GasExposureAnalytics(object):
             self.logger.critical(message)
             critical_config_issues += [message]
 
+        # Check the max number of auto-filled minutes is a positive integer.
+        if  ( (not isinstance(self.AUTOFILL_MINS, int)) or (not (self.AUTOFILL_MINS >= 0) ) ) :            
+            valid_config = False
+            message = "%s : '%s' should be a positive integer, but is %s" \
+                % (CONFIG_FILENAME, AUTOFILL_MINS_PROPERTY, self.AUTOFILL_MINS)
+            self.logger.critical(message)
+            critical_config_issues += [message]
+        elif (self.AUTOFILL_MINS > 20) :
+            # Recommended (but not enforced) to be less than 20 mins.
+            warning = "%s : '%s' is not recommended to be moreo than 20 minutes, but is %s" \
+                % (CONFIG_FILENAME, AUTOFILL_MINS_PROPERTY, self.AUTOFILL_MINS)
+            self.logger.warning(warning)
+
         assert valid_config, ''.join([('\nCONFIG ISSUE (%s) : %s' % (idx+1, issue)) for idx, issue in enumerate(critical_config_issues)])
 
         return
@@ -107,6 +129,10 @@ class GasExposureAnalytics(object):
     def __init__(self, list_of_csv_files=None):
 
         self.logger = logging.getLogger('GasExposureAnalytics')
+
+        # todo: documentation
+        # Cache of 'earliest and latest observed data points for each firefighter'.
+        self._FF_TIME_SPANS_CACHE = None
 
         # Get configuration
         with open(os.path.join(os.path.dirname(__file__), CONFIG_FILENAME)) as file:
@@ -128,6 +154,9 @@ class GasExposureAnalytics(object):
         #   e.g.: At time of writing, Nitrogen Dioxide had the smallest range at 0.10 to 0.44, so the safe rounding
         #   factor for exposure calculations was 3 decimal places.
         self.SAFE_ROUNDING_FACTOR = configuration[SAFE_ROUNDING_FACTOR_PROPERTY]
+
+        # todo: documentation
+        self.AUTOFILL_MINS = configuration[AUTOFILL_MINS_PROPERTY]
 
         # Validate the configuration - log helpful error messages if invalid.
         self._validate_config()
@@ -163,40 +192,68 @@ class GasExposureAnalytics(object):
     # Query the last N hours of sensor logs, where N is the longest TWA window length. This
     # method assumes that sensor data is stored against a minute-floor timestamp key - i.e.
     # that a sensor value captured at 12:00:05 is stored against a timestamp of 12:00:00.
-    # window_end : The datetime from which to look back when reading the sensor logs (e.g. 'now').
-    def _get_block_of_sensor_readings(self, window_end) :
+    # block_end : The datetime from which to look back when reading the sensor logs (e.g. 'now').
+    def _get_block_of_sensor_readings(self, block_end) :
         
         # very important: everything in the system needs to synchronise to minute-boundaries
-        window_end = window_end.floor(freq='min')
-        longest_window = max([window['mins'] for window in self.WINDOWS_AND_LIMITS])
-        window_start = window_end - pd.Timedelta(minutes = longest_window) # e.g. 8hrs ago
+        block_end = block_end.floor(freq='min')
+        longest_block = max([window['mins'] for window in self.WINDOWS_AND_LIMITS])
+        block_start = block_end - pd.Timedelta(minutes = longest_block) # e.g. 8hrs ago
 
         sensor_log_df = pd.DataFrame()
+        ff_time_spans_df = None
         if self._from_db :
             # Get from database
             # Three ways to think about, depending on how time is being reported and whether this is running 'live' or in testing mode
             # 1. Get a RANGE
             # todo: check if this is inclusive or right/left exclusive - may be the source of the 'last TWA calculation of the day' issue?
-            sql = "SELECT * FROM " + SENSOR_LOG_TABLE + " where " + TIMESTAMP_COL + " between '" + window_start.isoformat() + "' and '" + window_end.isoformat() + "'"
+            sql = "SELECT * FROM " + SENSOR_LOG_TABLE + " where " + TIMESTAMP_COL + " between '" + block_start.isoformat() + "' and '" + block_end.isoformat() + "'"
             # 2. Get the LAST 8 HOURS (using the app server's perception of 'now')
-            # sql = "SELECT * FROM " + SENSOR_LOG_TABLE + " where " + TIMESTAMP_COL + " > '" + window_start.isoformat() + "'"
+            # sql = "SELECT * FROM " + SENSOR_LOG_TABLE + " where " + TIMESTAMP_COL + " > '" + block_start.isoformat() + "'"
             # 3. Get the LAST 8 HOURS (using the database's perception of 'now')
             # sql = "SELECT * FROM " + SENSOR_LOG_TABLE + " where " + TIMESTAMP_COL + " > (DATE_SUB(NOW(), INTERVAL 8 HOUR))
             sensor_log_df = pd.read_sql_query(sql, self._db_engine, parse_dates=[TIMESTAMP_COL], index_col=TIMESTAMP_COL).sort_index()
 
         else :
             # Get from local CSV files - useful when testing (e.g. using CSV data from the February test)
-            sensor_log_df = self._sensor_log_from_csv_df.loc[window_start:window_end,:].sort_index().copy()
+            sensor_log_df = self._sensor_log_from_csv_df.loc[block_start:block_end,:].sort_index().copy()
 
-        if (sensor_log_df.empty) : self.logger.info("No 'live' sensor records found in range [%s to %s]" % (str(window_start), str(window_end)))
+        if (sensor_log_df.empty) :
+            self.logger.info("No 'live' sensor records found in range [%s to %s]" % (str(block_start), str(block_end)))
+            # Reset the cache of 'earliest and latest observed data points for each firefighter'.
+            # If we didn't do this, firefighters 'data time span' would stretch over multiple days. We want
+            # it to reset once there's been no data within the longest configured time-window.
+            self._FF_TIME_SPANS_CACHE = None
 
-        return sensor_log_df
+        else : 
+            # Update the cache of 'earliest and latest observed data points for each firefighter'. As firefighters come online,
+            # each new chunk may contain records for firefighters that are not yet captured in the cache.
+            # [DATA_START]: the earliest observed data point for each firefighter - grows as firefighters
+            #                 join an event (and different for each Firefighter)
+            # [DATA_END]  : the latest observed data point for each firefighter so far - a moving target, but
+            #                 fixed for *this* chunk of data (and potentially different for each Firefighter)
+            ff_time_spans_in_this_block = (pd.DataFrame(sensor_log_df.reset_index().groupby(FIREFIGHTER_ID_COL)[TIMESTAMP_COL].agg(['min', 'max']))
+                                                .rename(columns = {'min':DATA_START, 'max':DATA_END}))
+            if self._FF_TIME_SPANS_CACHE is None :
+                self._FF_TIME_SPANS_CACHE = pd.DataFrame(ff_time_spans_in_this_block)
+            else :  
+                # note: use pd.merge() not pd.concat() - concat drops the index names causing later steps to crash
+                self._FF_TIME_SPANS_CACHE = pd.merge(np.fmin(ff_time_spans_in_this_block[DATA_START], self._FF_TIME_SPANS_CACHE[DATA_START]),
+                                                    np.fmax(ff_time_spans_in_this_block[DATA_END], self._FF_TIME_SPANS_CACHE[DATA_END]),
+                                                    how='outer', on=FIREFIGHTER_ID_COL)
+
+            # todo: documentation
+            ff_time_spans_df = self._FF_TIME_SPANS_CACHE.copy()
+            ff_time_spans_df[DATA_END] = ff_time_spans_df[DATA_END] + pd.Timedelta(minutes = self.AUTOFILL_MINS)
+
+        return sensor_log_df, ff_time_spans_df
 
 
     # Given up to 8 hours of data, calculates the time-weighted average and limit gauge (%) for all firefighters, for all supported gases, for all configured time periods.
     # sensor_log_chunk_df  : A time-indexed dataframe covering up to 8 hours of sensor data for all firefighters, for all supported gases. Requires firefighterID and supported gases as columns.
+    # ff_time_spans_df : todo documentation
     # current_timestamp    : The timstamp for which to calculate time-weighted averages (e.g. 'now').
-    def _calculate_TWA_and_gauge_for_all_firefighters(self, sensor_log_chunk_df, current_timestamp) :
+    def _calculate_TWA_and_gauge_for_all_firefighters(self, sensor_log_chunk_df, ff_time_spans_df, current_timestamp) :
 
         # We'll be processing the windows in descending order of length (mins) 
         windows_in_descending_order = sorted([window for window in self.WINDOWS_AND_LIMITS], key=lambda window: window['mins'], reverse=True)
@@ -205,88 +262,108 @@ class GasExposureAnalytics(object):
         slice_correction = pd.Timedelta(minutes = 1) # subtract 1 min because pandas index slicing is __inclusive__ and we don't want 11 samples in a 10 min average
         timestamp_correction = pd.Timedelta(minutes = 1)
 
-        longest_window_df = sensor_log_chunk_df[(current_timestamp - longest_window_timedelta + slice_correction).isoformat():current_timestamp.isoformat()]
+        longest_window_df = sensor_log_chunk_df[(current_timestamp - longest_window_timedelta + slice_correction):current_timestamp]
 
-        # todo: Obtain information about long dropouts (>3mins) before resampling. Each TWA will need this to confirm there's enough info for calculating that TWA.
-        # todo: long-dropout detection goes here
-        
-        
-        # To calculate time-weighted averages, every time-slice in the window is quantized to equal 1-minute lengths.
-        # (it can be done with 'ragged' / uneven time-slices, but the code is more complex and hence error-prone, so we use 1-min quantization as standard here).
-        # We still have to fill-in missing minutes (e.g. while a device was offline).
-        # When a sensor value isn't known for any *short* period (e.g. 3mins), we'll assume that the value observed at the end of that period is
-        # a reasonable approximation of its value during that period. i.e. we 'backfill' those gaps. (note: On the US standard
-        # websites (OSHA, NIOSH), it seems that only sampling every 10 mins or even every hour is common. So backfilling a small number of
-        # missing minutes seems a reasonable strategy)
-
-        # Resample the data to 1 minute boundaries, grouped by firefighter and backfilling any missing minutes
+        # To calculate time-weighted averages, every time-slice in the window is quantized ('resampled') to equal 1-minute lengths.
+        # (it can be done with 'ragged' / uneven time-slices, but the code is more complex and hence error-prone, so we use 1-min
+        # quantization as standard here). We won't backfill missing entries here. Later, we will fill missing entries with an average.
         resample_timedelta = pd.Timedelta(minutes = 1)
         longest_window_cleaned_df = (longest_window_df
                                     .sort_index()
                                     .groupby(FIREFIGHTER_ID_COL, group_keys=False)
-                                    .resample(resample_timedelta).backfill(limit=3)
+                                    .resample(resample_timedelta).nearest(limit=1)
                                     )
         
         # We're about to calculate stats for a number of different time-windows and then join them together.
         # To do so, we need a common timestamp/key to merge on - same as the sensor records timestamp/key (assuming there are any).
         # Since records are quantized to floor(minute), they need a 1 minute arrival buffer, hence this correction.
         common_key = (current_timestamp - timestamp_correction).floor(freq='min')
-
-
         
-        
-        # Now, get the 'latest' sensor readings - may or may not be available, depending on dropouts
-        latest_sensor_readings = [] # store for merging later on
+        # Before doing the main work, save a copy of the data for each device at 'current_timestamp' (may or may not be available, depending on dropouts)
+        latest_device_data = []
         if (common_key in longest_window_cleaned_df.index) :
-            # If there's a 'latest' sensor reading available, get it. Lots of info here isn't used for analytics and
-            # will need to be merged back into the final dataframe. (The analytics only needs the supported gases and
-            # firefighter_id). Fields that aren't used for analytics include some sensor fields (e.g. humidity, 
-            # temperature, ...) and many non-sensor fields (e.g. device_id, device_battery_level, ...)
+            # If there's data for a device at 'current_timestamp', get a copy of it. While some if it is used for calculating
+            # average exposures (e.g. gases, times, firefighter_id), much of it is not (e.g. temperature, humidity, battery
+            # level) and this data needs to be merged back into the final dataframe.
             latest_sensor_readings_df = (longest_window_cleaned_df
                                         .loc[[common_key],:] # the current timeslice
                                         .reset_index()
-                                        .set_index([FIREFIGHTER_ID_COL, TIMESTAMP_COL])  # match up the indexing to the TWA dataframes
+                                        .set_index([FIREFIGHTER_ID_COL, TIMESTAMP_COL])  # standardise the index for merging data, TWA & Gauge data at the end
                                         )
             # Store for merging later on
-            latest_sensor_readings = [latest_sensor_readings_df] 
+            latest_device_data = [latest_sensor_readings_df] 
         else : 
             self.logger.info(" No 'live' sensor records found at timestamp %s. Calculating Time-Weighted Averages anyway..." % (common_key.isoformat()))
         
-        # Now iterate over the time windows, calculate their time-weighted averages & limit gauge %, and merge them to a common dataframe
+        # Now the main body of work - iterate over the time windows, calculate their time-weighted averages & limit gauge percentages.
+        # Then merge all of these bits of info back together (with the original device data) to forma the overall analytic results dataframe.
         calculations_for_all_windows = [] # list of results from each window, for merging at the end
-        for window in windows_in_descending_order :
-            window_mins = window['mins']
+        for time_window in windows_in_descending_order :
+            window_mins = time_window['mins']
             window_timedelta = pd.Timedelta(minutes = window_mins)
-            window_duration_label = window['label']
+            window_duration_label = time_window['label']
             
-            # get a slice for this specific window, for all supported gas sensor readings (and excluding anll other columns)
+            # Get the relevant slice of the data for this specific time-window, for all supported gas sensor readings (and excluding anll other columns)
             analytic_cols = self.SUPPORTED_GASES + [FIREFIGHTER_ID_COL]
             window_df = (longest_window_cleaned_df
                         .loc[(current_timestamp - window_timedelta + slice_correction).isoformat():current_timestamp.isoformat(), analytic_cols])
-            
-            # If the window is empty, we still need to append it to the 'everything' dataframe
+                        #todo: check and remove isoformat()
+
+            # If the window is empty, then there's nothing to do, just move on to the next window
             if (window_df.empty) :
-                # # Update column titles - add the time period over which we're averaging, so we can merge dataframes later without column name conflicts
-                # empty_df = window_df.reset_index().set_index([FIREFIGHTER_ID_COL, TIMESTAMP_COL])
-                # empty_twa_df = empty_df.add_suffix('_' + TWA_SUFFIX + '_' + window_duration_label)
-                # empty_gauge_df = empty_df.add_suffix('_' + GAUGE_SUFFIX + '_' + window_duration_label)
-                # # Now save the results from this time window as a single merged dataframe (TWAs and Limit Gauges)
-                # calculations_for_all_windows.append(pd.concat([empty_twa_df, empty_gauge_df], axis='columns'))
-                continue # TODO: think we probably don't need this - if we're only writing back to the DB, the null cols will be fine.
+                continue
 
             # Sanity check that there's never more data in the window than there should be (1 record per minute per FF, max)
             assert(window_df.groupby(FIREFIGHTER_ID_COL).size().max() <= window_mins)
 
-            # Confirm there's enough info to calculate with, using information about gaps obtained before resampling
-            # todo: check here whether to calculate or return NaN, based on max length of dropouts / disconnected periods.
-            
-            
-            
-            # Calculate time-weighted average exposure
-            window_sample_count = window_timedelta / resample_timedelta
-            # Use .sum() and divide by a fixed-time denominator for each window.
-            # Don't use .mean() - it has a variable denominator (however many datapoints it happens to have), which over-estimates exposure during startup.
-            window_twa_df = np.round((window_df.groupby(FIREFIGHTER_ID_COL).sum() / float(window_sample_count)), self.SAFE_ROUNDING_FACTOR)
+            # Calculate time-weighted average exposure for this time-window.
+            # A *time-weighted* average, means each sensor reading is multiplied by the length of time the reading covers,
+            # before dividing by the total time covered. This can get very complicated if readings are unevenly spaced or if they
+            # get lost, or sent late due to connectivity dropouts. So the Prometeo system makes two design choices that
+            # account for these issues, thereby simplifying calculations (and reducing opportunities for error).
+            # (1) The system takes exactly one reading per minute, no more & no less, so the multiplication factor for every
+            # reading is always 1.
+            # (2) Any missing/lost sensor readings are approximated by using the average value for that sensor over the
+            # time-window in question. (Care needs to be taken to ensure that calculations don't inadvertently approximate
+            # them as '0ppm').
+            # Since the goal we're after here is to get the average over a time-window, we don't need to actually fill-in the
+            # missing entries, we can just get the average of the sensor readings that we actually have.
+            window_twa_df = np.round(window_df.groupby(FIREFIGHTER_ID_COL).mean(), self.SAFE_ROUNDING_FACTOR)
+
+            # Note: the average is not enough, we also have to adjust it to reflect how much of the time-window the data
+            # represents. e.g. Say the 8hr time-weighted average (TWA) exposure limit for CO exposure is 27ppm. Now imagine
+            # we observe 30ppm in the first 15 mins of an event and then have a connectivity dropout for the next 15 mins.
+            # What do we show the command center user? It's over the limit for an 8hr average, but we're only 30mins into
+            # that 8-hour period. So we adjust the TWA to the proportion of the time window that has actually elapsed.
+            # Note: this implicitly assumes that firefighter exposure is zero before the first recorded sensor value and
+            # after the last recorded value.
+
+            # To work out the window proportion, we (A) calculate the time overlap between the moving window and the
+            # available data timespans for each Firefighter, then (B) Divide the overlap by the total length of the
+            # time-window to get the proportion. Finally (C) Multiply the TWAs for each firefighter by the proportion
+            # for that firefighter.
+
+            # (A.1) Get the available data timespans for each Firefighter, only selecting firefighters that are in this window.
+            # (copy because we're iterating over windows and we don't want data from one window contaminating the next)
+            overlap_df = ff_time_spans_df[ff_time_spans_df.index.isin(window_df[FIREFIGHTER_ID_COL].unique())].copy()
+
+            # (A.2) Add on the moving window timespans
+            overlap_df[WINDOW_START] = current_timestamp - window_timedelta
+            overlap_df[WINDOW_END] = current_timestamp
+
+            # (A.3) Calculate the overlap between the moving window and the available data timespans for each Firefighter.
+            # overlap = (earliest_end_time - latest_start_time). Negative overlap is meaningless, so when it happens,
+            # treat it as zero overlap.
+            overlap_df[OVERLAP_MINS] = ((overlap_df[[DATA_END,WINDOW_END]].min(axis='columns') - overlap_df[[DATA_START,WINDOW_START]].max(axis='columns'))
+                                         .transform(lambda overlap_delta: overlap_delta.total_seconds()/float(60) if overlap_delta.total_seconds() > 0 else 0))
+
+            # (B) Divide the overlap by the total length of the time-window to get the proportion.
+            overlap_df[PROPORTION_OF_WINDOW] = (overlap_df[OVERLAP_MINS]
+                                                .transform(lambda overlap_mins : overlap_mins/float(window_mins) if overlap_mins < window_mins else 1))
+
+            # (C) Multiply the TWAs for each firefighter by the proportion for that firefighter.
+            window_twa_df = window_twa_df.multiply(overlap_df[PROPORTION_OF_WINDOW], axis='rows')
+
             # Give the window its index key. Note: since records are quantized to floor(minute), they need a 1 minute arrival buffer, hence the correction
             window_twa_df[TIMESTAMP_COL] = common_key
 
@@ -295,7 +372,7 @@ class GasExposureAnalytics(object):
             
             # Calculate gas limit gauge - percentage over / under the calculated TWA values
             # (must compare gases in the same order as the dataframe columns)
-            limits_in_column_order = [float(window[GAS_LIMITS_PROPERTY][gas]) for gas in window_twa_df.columns if gas in self.SUPPORTED_GASES]
+            limits_in_column_order = [float(time_window[GAS_LIMITS_PROPERTY][gas]) for gas in window_twa_df.columns if gas in self.SUPPORTED_GASES]
             window_gauge_df = (window_twa_df * 100 / limits_in_column_order).round(0).astype(int) # whole integer percentage, don't need floats
 
             # Update column titles - add the time period over which we're averaging, so we can merge dataframes later without column name conflicts
@@ -306,10 +383,10 @@ class GasExposureAnalytics(object):
             calculations_for_all_windows.append(pd.concat([window_twa_df, window_gauge_df], axis='columns'))
 
         # Merge latest sensors readings with TWAs and Gauges from all time windows - so we have 'everything' for this time step
-        everything_for_1_min_df = pd.concat(latest_sensor_readings + calculations_for_all_windows, axis='columns')
+        everything_for_1_min_df = pd.concat(latest_device_data + calculations_for_all_windows, axis='columns')
 
         # If there were no latest sensors readings to merge, then just set all the sensor cols to null
-        if not latest_sensor_readings :
+        if not latest_device_data :
             # Do this for all sensor columns, except the two keys
             for col in list(set(sensor_log_chunk_df.columns) - set([FIREFIGHTER_ID_COL, TIMESTAMP_COL])) :
                 everything_for_1_min_df[col] = None # todo: works, but would prefer a more "pandas-y" way of achieving this with a multi-level index...
@@ -332,22 +409,22 @@ class GasExposureAnalytics(object):
     # time : The datetime for which to calculate sensor analytics. Defaults to 'now'.
     # commit : Utility flag for unit testing - defaults to committing analytic results to
     #          the database. Setting commit=False prevents unit tests from writing to the database.
-    def run_analytics (self, time=pd.Timestamp.now(), commit=True) :
+    def run_analytics (self, current_timestamp=pd.Timestamp.now(), commit=True) :
 
-        message = ("Running Prometeo Analytics. Looking for any sensor data arriving since %s" % (time.isoformat()))
+        message = ("Running Prometeo Analytics. Looking for any sensor data arriving since %s" % (current_timestamp.isoformat()))
         if not self._from_db : message += " (local CSV file mode)"
         self.logger.info(message)
         # Read the max window block from the database - todo: ensure this a non-blocking read (not read-for-update)
         # We can make this more performant, but at the start "make it correct, then write the tests, THEN optimise (with a safety net)" 
         # Also - this is robust to dropouts - querying 'everything known' from the sensor log ensures that
         # analytic processing can include any delayed records that have since arrived.
-        sensor_log_df = self._get_block_of_sensor_readings(time)
+        sensor_log_df, ff_time_spans_df = self._get_block_of_sensor_readings(current_timestamp)
 
         # Stop if there's no data (e.g. (1) after the system is booted but before any records have come in. (2) 8+ hours after an event
         if (sensor_log_df.empty) : return    
         
         # Work out all the time-weighted averages and corresponding limit gauges for all firefighters, all limits and all gases.
-        analytics_df = self._calculate_TWA_and_gauge_for_all_firefighters(sensor_log_df, time)
+        analytics_df = self._calculate_TWA_and_gauge_for_all_firefighters(sensor_log_df, ff_time_spans_df, current_timestamp)
 
         if commit :
             analytics_df.to_sql(ANALYTICS_TABLE, self._db_engine, if_exists='append', dtype={FIREFIGHTER_ID_COL:FIREFIGHTER_ID_COL_TYPE})

--- a/src/prometeo_config.json
+++ b/src/prometeo_config.json
@@ -9,5 +9,6 @@
     ],
 "supported_gases" :["carbon_monoxide", "nitrogen_dioxide"],
 "yellow_warning_percent" : 80,
-"safe_rounding_factor" : 3
+"safe_rounding_factor" : 3,
+"autofill_missing_sensor_logs_up_to_N_mins" : 10
 }


### PR DESCRIPTION
Handle dropouts in the Prometeo sensor data by substituting TWA window-specific averages for missing values. Also added a configuration options for specifying the max number of minutes of missing data to treat as an average. This is needed so that Prometeo can understand when the loss of sensor data indicates that the device is off and the current exposure can reasonably be assumed to have reverted to zero.

Improved Documentation to follow.

Linked to https://github.com/Code-and-Response/Prometeo/issues/115