### PR TITLE
Fix command description for the Docker image of MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can run this solution locally in docker as follows
    1. Run the image
 
       ```bash
-      docker run -p 3306:3306 --name pyrrha-mariadb -e MYSQL_ROOT_PASSWORD='' -d mariadb
+      docker run --rm -p 3306:3306 --name pyrrha-mariadb -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=true -d mariadb
       ```
 
    1. Test the image - TBD


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
The command that is shown in the README.md is incorrect when using a MariaDB Docker Image.

MariaDB accepts one of the following three environment variables: 

- `MARIADB_ROOT_PASSWORD` 
- `MARIADB_ALLOW_EMPTY_ROOT_PASSWORD`
- `MARIADB_RANDOM_ROOT_PASSWORD`

Probably the documentation comes from the usage of a previous version of MariaDB.

Also, if the flag `--rm` isn't added when the container is created, the user after exiting that container won't be able to create it again, since the name will be attached to the stopped container.

**Is this a patch, a minor version change, or a major version change**
Patch.

**Is this related to an open issue?**
https://github.com/Pyrrha-Platform/Pyrrha-Rules-Decision/issues/47
