### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/microservices/
 COPY requirements.txt .
 RUN pip install -r /opt/microservices/requirements.txt
 
-COPY src/* .
+COPY src/* ./
 RUN [ -f ".env" ] || cp .env.docker .env
 
 ENTRYPOINT ["python", "core_decision_flask_app.py", "8080"]


### PR DESCRIPTION
There is an actual bug on the dockerfile utils, when no BuildKit is used then the destination folder must be with a trailing slash

Original bug: https://github.com/moby/buildkit/issues/1853

Signed-off-by: Daniel Campos Olivares <dacamposol@gmail.com>
