### PR TITLE
Use RedHat technical information to avoid further possible vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ EXPOSE 8080
 
 ENV PYTHONUNBUFFERED=1
 
-WORKDIR /opt/microservices/
+COPY --chown=1001 requirements.txt .
+RUN pip install -r /opt/app-root/src/requirements.txt
 
-COPY requirements.txt .
-RUN pip install -r /opt/microservices/requirements.txt
+COPY --chown=1001 src/* ./
 
-COPY src/* ./
 RUN [ -f ".env" ] || cp .env.docker .env
 
 ENTRYPOINT ["python", "core_decision_flask_app.py", "8080"]


### PR DESCRIPTION
The problem on build time is derived from the conditions of the base image.

![image](https://user-images.githubusercontent.com/16921751/137199110-e288c49b-5b3e-4dc3-bcab-b4e96ecea2ad.png)

Changing the usage of the image to adapt to these conditions should solve any further problem.

Signed-off-by: Daniel Campos Olivares <dacamposol@gmail.com>